### PR TITLE
Render math without `# noqa: W605 comment`

### DIFF
--- a/skmatter/linear_model/_base.py
+++ b/skmatter/linear_model/_base.py
@@ -8,13 +8,15 @@ from sklearn.linear_model import LinearRegression
 
 
 class OrthogonalRegression(MultiOutputMixin, RegressorMixin):
-    """Orthogonal regression by solving the Procrustes problem
+    r"""Orthogonal regression by solving the Procrustes problem
 
     Linear regression with the additional constraint that the weight matrix
     must be an orthogonal matrix/projection. It minimizes the Procrustes
     problem:
 
-    :math:`\min_\Omega ||y - X\Omega\||_F \quad\mathrm{subject\ to}\quad \Omega^T\Omega=I` % # noqa: W605
+    .. math::
+
+        \min_\Omega ||y - X\Omega\||_F \quad\mathrm{subject\ to}\quad \Omega^T\Omega=I
 
     Parameters
     ----------

--- a/skmatter/linear_model/_ridge.py
+++ b/skmatter/linear_model/_ridge.py
@@ -15,7 +15,9 @@ class RidgeRegression2FoldCV(MultiOutputMixin, RegressorMixin):
     r"""Ridge regression with an efficient 2-fold cross-validation method using the SVD solver.
     Minimizes the objective function:
 
-    :math: \|y - Xw\|^2_2 + \alpha \|w\|^2_2, % # noqa: W605
+    .. math::
+
+        \|y - Xw\|^2_2 + \alpha \|w\|^2_2,
 
     while the alpha value is determined with a 2-fold cross-validation from a list of
     alpha values. It is more efficient than doing a 2-fold cross-validation using

--- a/skmatter/metrics/_reconstruction_measures.py
+++ b/skmatter/metrics/_reconstruction_measures.py
@@ -378,7 +378,7 @@ def pointwise_local_reconstruction_error(
 
     .. math::
 
-        LRE^{(i)}(X,Y) = \|\mathbf{x}'_i - \tilde{\mathbf{x}}'_i\|^2`
+        LRE^{(i)}(X,Y) = \|\mathbf{x}'_i - \tilde{\mathbf{x}}'_i\|^2
 
     If used with X and Y of shape (n_samples, n_features) it computes the pointwise
     local reconstruction error of the features as defined in Ref. [Goscinski2021]_.

--- a/skmatter/metrics/_reconstruction_measures.py
+++ b/skmatter/metrics/_reconstruction_measures.py
@@ -20,11 +20,13 @@ def pointwise_global_reconstruction_error(
     scaler=None,
     estimator=None,
 ):
-    """Computes the pointwise global reconstruction error using the source X
+    r"""Computes the pointwise global reconstruction error using the source X
     to reconstruct the features or samples of target Y based on a minimization
     by linear regression:
 
-    :math:`GRE^{(i)}(X,Y) = \min_W ||y_i - x_iW||` % # noqa: W605
+    .. math::
+
+        GRE^{(i)}(X,Y) = \min_W ||y_i - x_iW||
 
     If used with X and Y of shape (n_samples, n_features) it computes the pointwise
     global reconstruction error of the features as defined in Ref. [Goscinski2021]_.
@@ -109,11 +111,13 @@ def global_reconstruction_error(
     scaler=None,
     estimator=None,
 ):
-    """Computes the global reconstruction error using the source X
+    r"""Computes the global reconstruction error using the source X
     to reconstruct the features or samples of target Y based on a minimization
     by linear regression:
 
-    :math:`GRE(X,Y) = \min_W ||Y - XW||`` % # noqa: W605
+    .. math::
+
+        GRE(X,Y) = \min_W ||Y - XW||
 
     If used with X and Y of shape (n_samples, n_features) it computes the
     global reconstruction error of the features as defined in Ref. [Goscinski2021]_.
@@ -186,11 +190,13 @@ def pointwise_global_reconstruction_distortion(
     scaler=None,
     estimator=None,
 ):
-    """Computes the pointwise global reconstruction distortion using the source X
+    r"""Computes the pointwise global reconstruction distortion using the source X
     to reconstruct the features or samples of target Y based on a minimization
     by orthogonal regression:
 
-    :math:`GRD^{(i)}(X,Y) = \min_Q ||y_i - x_iQ\|| \quad\mathrm{subject\ to}\quad Q^TQ=I` % # noqa: W605
+    .. math::
+
+        GRD^{(i)}(X,Y) = \min_Q ||y_i - x_iQ\|| \quad\mathrm{subject\ to}\quad Q^TQ=I
 
     If used with X and Y of shape (n_samples, n_features) it computes the pointwise
     global reconstruction distortion of the features as defined in Ref. [Goscinski2021]_.
@@ -280,11 +286,13 @@ def global_reconstruction_distortion(
     scaler=None,
     estimator=None,
 ):
-    """Computes the global reconstruction distortion using the source X
+    r"""Computes the global reconstruction distortion using the source X
     to reconstruct the features or samples of target Y based on a minimization
     by orthogonal regression:
 
-    :math:`GRD(X,Y) = \min_Q ||y - XQ\|| \quad\mathrm{subject\ to}\quad Q^TQ=I` % # noqa: W605
+    .. math::
+
+        GRD(X,Y) = \min_Q ||y - XQ\|| \quad\mathrm{subject\ to}\quad Q^TQ=I
 
     If used with X and Y of shape (n_samples, n_features) it computes the
     global reconstruction distortion of the features as defined in Ref. [Goscinski2021]_.
@@ -363,8 +371,14 @@ def pointwise_local_reconstruction_error(
     to reconstruct the features or samples of target Y based on a minimization
     by linear regression:
 
-    :math:`\tilde{\mathbf{x}}'_i = \bar{\mathbf{x}} + (\mathbf{x}_i - \bar{\mathbf{x}})\mathbf{P}^{(i)}` % # noqa: W605
-    :math:`LRE^{(i)}(X,Y) = \|\mathbf{x}'_i - \tilde{\mathbf{x}}'_i\|^2` % # noqa: W605
+    .. math::
+
+        \tilde{\mathbf{x}}'_i = \bar{\mathbf{x}} + (\mathbf{x}_i
+                                - \bar{\mathbf{x}})\mathbf{P}^{(i)}
+
+    .. math::
+
+        LRE^{(i)}(X,Y) = \|\mathbf{x}'_i - \tilde{\mathbf{x}}'_i\|^2`
 
     If used with X and Y of shape (n_samples, n_features) it computes the pointwise
     local reconstruction error of the features as defined in Ref. [Goscinski2021]_.
@@ -493,7 +507,9 @@ def local_reconstruction_error(
     to reconstruct the features or samples of target Y based on a minimization
     by linear regression:
 
-    :math:`LRE(X,Y) = \sqrt{\sum_i LRE^{(i)}(X,Y)}/\sqrt{n_\text{test}}` % # noqa: W605
+    .. math::
+
+        LRE(X,Y) = \sqrt{\sum_i LRE^{(i)}(X,Y)}/\sqrt{n_\text{test}}
 
     If used with X and Y of shape (n_samples, n_features) it computes the
     local reconstruction error of the features as defined in Ref. [Goscinski2021]_.


### PR DESCRIPTION
Math rendering in the docstrings is inline with a `# noqa` to prevent the linter to be unhappy. However, this makes the equations harder to understand. This PR converts the inline math equations to block math.