### PR TITLE
Add flake8-bugbear and flake8-sphinx-links

### DIFF
--- a/src/skmatter/_selection.py
+++ b/src/skmatter/_selection.py
@@ -192,7 +192,7 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
             raise ValueError(error_msg)
 
         if warm_start:
-            if not hasattr(self, "n_selected_") or getattr(self, "n_selected_") == 0:
+            if not hasattr(self, "n_selected_") or self.n_selected_ == 0:
                 raise ValueError(
                     "Cannot fit with warm_start=True without having been previously"
                     " initialized."
@@ -210,7 +210,8 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
             else:
                 warnings.warn(
                     f"Score threshold of {self.score_threshold} reached."
-                    f"Terminating search at {self.n_selected_} / {self.n_to_select}."
+                    f"Terminating search at {self.n_selected_} / {self.n_to_select}.",
+                    stacklevel=1,
                 )
                 self.X_selected_ = np.take(
                     self.X_selected_, np.arange(self.n_selected_), axis=self._axis

--- a/src/skmatter/decomposition/_kernel_pcovr.py
+++ b/src/skmatter/decomposition/_kernel_pcovr.py
@@ -111,7 +111,7 @@ class KernelPCovR(_BasePCA, LinearModel):
 
     n_jobs: int, default=None
         The number of parallel jobs to run.
-        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
+        :obj:`None` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors.
 
     iterated_power : int or 'auto', default='auto'

--- a/src/skmatter/decomposition/_pcovr.py
+++ b/src/skmatter/decomposition/_pcovr.py
@@ -257,7 +257,8 @@ class PCovR(_BasePCA, LinearModel):
         if np.max(np.abs(self.mean_)) > self.tol:
             warnings.warn(
                 "This class does not automatically center data, and your data mean is"
-                " greater than the supplied tolerance."
+                " greater than the supplied tolerance.",
+                stacklevel=1,
             )
 
         if self.space is not None and self.space not in [
@@ -605,7 +606,8 @@ class PCovR(_BasePCA, LinearModel):
             warnings.warn(
                 "This class does not automatically un-center data, and your data mean "
                 "is greater than the supplied tolerance, so the inverse transformation "
-                "will be off by the original data mean."
+                "will be off by the original data mean.",
+                stacklevel=1,
             )
 
         return T @ self.ptx_

--- a/src/skmatter/linear_model/_ridge.py
+++ b/src/skmatter/linear_model/_ridge.py
@@ -62,7 +62,7 @@ class RidgeRegression2FoldCV(MultiOutputMixin, RegressorMixin):
         If None, the negative mean squared error is used.
     n_jobs : int, default=None
         The number of CPUs to use to do the computation.
-        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
+        :obj:`None` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See
         `n_jobs glossary from sklearn (external link) <https://scikit-learn.org/stable/glossary.html#term-n-jobs>`_
         for more details.

--- a/src/skmatter/sample_selection/_base.py
+++ b/src/skmatter/sample_selection/_base.py
@@ -680,6 +680,7 @@ class DirectionalConvexHull:
                 "There are samples in X with a low-dimensional part that is outside "
                 "of the range of the convex surface. Distance will contain nans.",
                 UserWarning,
+                stacklevel=1,
             )
 
         # determine the distance between the original high-dimensional data and

--- a/src/skmatter/sample_selection/_voronoi_fps.py
+++ b/src/skmatter/sample_selection/_voronoi_fps.py
@@ -153,8 +153,8 @@ class VoronoiFPS(GreedySelector):
                 raise ValueError(
                     "Number of trial calculation should be more or equal to 1"
                 )
-            for i in range(self.n_trial_calculation):
-                _ = X @ X[[0]].T
+            for _ in range(self.n_trial_calculation):
+                X @ X[[0]].T
             simple_fps_timing += time()
             simple_fps_timing /= self.n_trial_calculation
 

--- a/src/skmatter/utils/_orthogonalizers.py
+++ b/src/skmatter/utils/_orthogonalizers.py
@@ -54,7 +54,7 @@ def X_orthogonalizer(x1, c=None, x2=None, tol=1e-12, copy=False):
         col = cols[:, [i]]
 
         if np.linalg.norm(col) < tol:
-            warnings.warn("Column vector contains only zeros.")
+            warnings.warn("Column vector contains only zeros.", stacklevel=1)
         else:
             col /= np.linalg.norm(col, axis=0)
 

--- a/tests/test_kernel_pcovr.py
+++ b/tests/test_kernel_pcovr.py
@@ -56,7 +56,7 @@ class KernelPCovRErrorTest(KernelPCovRBaseTest):
         """
         prev_error = -1.0
 
-        for i, mixing in enumerate(np.linspace(0, 1, 6)):
+        for mixing in np.linspace(0, 1, 6):
             kpcovr = KernelPCovR(mixing=mixing, n_components=2, tol=1e-12)
             kpcovr.fit(self.X, self.Y)
 
@@ -81,7 +81,7 @@ class KernelPCovRErrorTest(KernelPCovRBaseTest):
         prev_error = 10.0
         prev_x_error = 10.0
 
-        for i, mixing in enumerate(np.linspace(0, 1, 6)):
+        for mixing in np.linspace(0, 1, 6):
             kpcovr = KernelPCovR(
                 mixing=mixing, n_components=2, fit_inverse_transform=True, tol=1e-12
             )
@@ -108,7 +108,7 @@ class KernelPCovRErrorTest(KernelPCovRBaseTest):
             prev_x_error = x_error
 
     def test_kpcovr_error(self):
-        for i, mixing in enumerate(np.linspace(0, 1, 6)):
+        for mixing in np.linspace(0, 1, 6):
             kpcovr = self.model(
                 mixing=mixing,
                 regressor=KernelRidge(kernel="rbf", gamma=1.0),
@@ -176,7 +176,7 @@ class KernelPCovRInfrastructureTest(KernelPCovRBaseTest):
         kpcovr.fit(self.X, self.Y)
 
         with self.assertRaises(AttributeError):
-            _ = getattr(kpcovr, "centerer_")
+            kpcovr.centerer_
 
     def test_centerer(self):
         """

--- a/tests/test_pcovr.py
+++ b/tests/test_pcovr.py
@@ -97,7 +97,7 @@ class PCovRErrorTest(PCovRBaseTest):
         """
         prev_error = -1.0
 
-        for i, mixing in enumerate(np.linspace(0, 1, 11)):
+        for mixing in np.linspace(0, 1, 11):
             pcovr = self.model(mixing=mixing, n_components=2, tol=1e-12)
             pcovr.fit(self.X, self.Y)
 
@@ -120,7 +120,7 @@ class PCovRErrorTest(PCovRBaseTest):
 
         prev_error = -1.0
 
-        for i, mixing in enumerate(np.linspace(0, 1, 11)):
+        for mixing in np.linspace(0, 1, 11):
             pcovr = self.model(mixing=mixing, n_components=2, tol=1e-12)
             pcovr.fit(self.X, self.Y)
 
@@ -143,7 +143,7 @@ class PCovRErrorTest(PCovRBaseTest):
 
         prev_error = 1.0
 
-        for i, mixing in enumerate(np.linspace(0, 1, 11)):
+        for mixing in np.linspace(0, 1, 11):
             pcovr = self.model(mixing=mixing, n_components=2, tol=1e-12)
             pcovr.fit(self.X, self.Y)
 

--- a/tox.ini
+++ b/tox.ini
@@ -37,8 +37,10 @@ commands =
 [testenv:lint]
 skip_install = true
 deps =
-    flake8
     black
+    flake8
+    flake8-bugbear
+    flake8-sphinx-links
     isort
 commands =
     flake8 {[tox]lint_folders}


### PR DESCRIPTION
Introduce linters for possible bugs (`flake8-bugbear`) and correct sphinx links in the docs (`flake8-sphinx-links`).

Besides some minor changes the most noticable change is setting the `stacklevel` of warnings since this is required by [flake8-bugbear](https://github.com/PyCQA/flake8-bugbear):

> B028: No explicit stacklevel keyword argument found. The warn method from the warnings module uses a stacklevel of 1 by default. This will only show a stack trace for the line on which the warn method is called. It is therefore recommended to use a stacklevel of 2 or greater to provide more information to the user.

Here, I set the level to `stacklevel=1` (the default) meaning that no additional backtrace information is given. I think we do not need more information for the user because the warnings are well written and a link and codeblock does not help much. If you disagree we can also set it to `2` or `3`.

We had already a discussion in [equistore](https://github.com/lab-cosmo/equistore/pull/124).

<!-- readthedocs-preview scikit-matter start -->
----
:books: Documentation preview :books:: https://scikit-matter--178.org.readthedocs.build/en/178/

<!-- readthedocs-preview scikit-matter end -->