### PR TITLE
Rerestructure requirements after #171

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -25,4 +25,5 @@ python:
     - method: pip
       path: .
       extra_requirements:
+        # The documentation runs "examples" to produce outputs via sphinx-gallery.
         - examples

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,3 @@
-matplotlib
-pandas
 sphinx
 sphinx_rtd_theme
 sphinx-gallery
-ase
-tqdm

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,8 +1,0 @@
-pandas
-jupyter
-jupyter_contrib_nbextensions
-matplotlib
-tqdm
-numpy
-scikit-learn
-ase

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 examples = [
+    "ase",
     "matplotlib",
     "pandas",
     "tqdm",

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,0 @@
-coverage[toml]
-parameterized
-tqdm
-ase

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,11 @@ lint_folders = "{toxinidir}/src" "{toxinidir}/tests" "{toxinidir}/docs/src/" "{t
 [testenv:tests]
 usedevelop = true
 changedir = tests
-deps = -rtests/requirements.txt
+deps =
+    ase
+    coverage[toml]
+    parameterized
+    tqdm
 
 commands =
     coverage run -m unittest discover -p "*.py"
@@ -46,6 +50,7 @@ commands =
 usedevelop = true
 deps =
     -r docs/requirements.txt
+# The documentation runs "examples" to produce outputs via sphinx-gallery.
 extras = examples
 commands = sphinx-build {posargs:-E} -W -b html docs/src docs/build/html
 


### PR DESCRIPTION
As a little aftermath to #171 this PR resorts the requirements for the examples.

_Background_: The requirements for the examples do not live in an extra file in examples anymore but can be installed directly when skmatter is installed using

```bash
pip install skmatter[examples]
```

This avoids duplications and makes it easier for users to work with our examples.

<!-- readthedocs-preview scikit-matter start -->
----
:books: Documentation preview :books:: https://scikit-matter--183.org.readthedocs.build/en/183/

<!-- readthedocs-preview scikit-matter end -->