### PR TITLE
Add more infos on landing pages & CODE_OF_CONDUCT

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+philip.loche@epfl.ch.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,16 @@
 scikit-matter
 =============
 
-|tests| |codecov| |docs| |pypi| |conda| |docs|
+|tests| |codecov| |pypi| |conda| |docs|
 
 A collection of scikit-learn compatible utilities that implement methods born out of the
 materials science and chemistry communities.
 
-.. installation
+For details, tutorials, and examples, please have a look at our `documentation`_.
+
+.. _`documentation`: https://scikit-matter.readthedocs.io
+
+.. marker-installation
 
 Installation
 ------------
@@ -27,7 +31,43 @@ or conda
 
 You can then `import skmatter` and use scikit-matter in your projects!
 
-.. contributors
+.. marker-issues
+
+Having problems or ideas?
+-------------------------
+
+Having a problem with scikit-matter? Please let us know by `submitting an issue
+<https://github.com/lab-cosmo/scikit-matter/issues>`_.
+
+Submit new features or bug fixes through a `pull request
+<https://github.com/lab-cosmo/scikit-matter/pulls>`_.
+
+.. marker-contributing
+
+Call for Contributions
+----------------------
+
+We always welcome new contributors. If you want to help us take a look at our
+`contribution guidelines`_ and afterwards you may start with an open issue marked as
+`good first issue`_.
+
+Writing code is not the only way to contribute to the project. You can also:
+
+* review `pull requests`_
+* help us stay on top of new and old `issues`_
+* develop `examples and tutorials`_
+* maintain and `improve our documentation`_
+* contribute `new datasets`_
+
+.. _`contribution guidelines`: https://scikit-matter.readthedocs.io/en/latest/contributing.html
+.. _`good first issue`: https://github.com/lab-cosmo/scikit-matter/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
+.. _`pull requests`: https://github.com/lab-cosmo/scikit-matter/pulls
+.. _`issues`: https://github.com/lab-cosmo/scikit-matter/issues
+.. _`improve our documentation`: https://scikit-matter.readthedocs.io/en/latest/contributing.html#contributing-to-the-documentation
+.. _`examples and tutorials`: https://scikit-matter.readthedocs.io/en/latest/contributing.html#contributing-new-examples
+.. _`new datasets`: https://scikit-matter.readthedocs.io/en/latest/contributing.html#contributing-datasets
+
+.. marker-contributors
 
 Contributors
 ------------
@@ -35,14 +75,7 @@ Contributors
 Thanks goes to all people that make scikit-matter possible:
 
 .. image:: https://contrib.rocks/image?repo=lab-cosmo/scikit-matter
-   :target: https://github.com/lab-cosmo/equistore/graphs/contributors
-
-We always welcome new contributors. If you want to help us take a look at
-our `contribution guidelines`_ and afterwards you may start with an open issue
-marked as `good first issue`_.
-
-.. _`contribution guidelines`: docs/src/contributing.rst
-.. _`good first issue`: https://github.com/lab-cosmo/scikit-matter/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
+   :target: https://github.com/lab-cosmo/scikit-matter/graphs/contributors
 
 .. |tests| image:: https://github.com/lab-cosmo/scikit-matter/workflows/Test/badge.svg
    :alt: Github Actions Tests Job Status

--- a/docs/src/contributing.rst
+++ b/docs/src/contributing.rst
@@ -3,11 +3,18 @@
 Contributing
 ============
 
-Start by installing the development dependencies:
+.. include:: ../../README.rst
+   :start-after: marker-contributing
+   :end-before: marker-contributors
+
+Getting started
+---------------
+
+To help with developing start by installing the development dependencies:
 
 .. code-block:: bash
 
-  pip install tox black flake8
+  pip install tox
 
 
 Then this package itself
@@ -22,7 +29,7 @@ This install the package in development mode, making it importable globally and 
 you to edit the code and directly use the updated version.
 
 Running the tests
-#################
+-----------------
 
 The testsuite is implemented using Python's `unittest`_ framework and should be set-up
 and run in an isolated virtual environment with `tox`_. All tests can be run with
@@ -50,7 +57,7 @@ are plugins to do this with `all major editors
 .. _tox: https://tox.readthedocs.io/en/latest
 
 Contributing to the documentation
-#################################
+---------------------------------
 
 The documentation is written in reStructuredText (rst) and uses `sphinx`_ documentation
 generator. In order to modify the documentation, first create a local version on your
@@ -74,18 +81,25 @@ following command (or open the :file:`docs/build/html/index.html` file manually)
 
 .. _`sphinx` : https://www.sphinx-doc.org
 
-Issues and Pull Requests
-########################
+Contributing new examples
+-------------------------
 
-Having a problem with scikit-matter? Please let us know by
-`submitting an issue <https://github.com/lab-cosmo/scikit-matter/issues>`_.
+The examples and tutorials are written as plain Python files and will be converted and
+rendered for the documentation using `Sphinx-Gallery
+<https://sphinx-gallery.github.io/stable/index.html>`.
 
-Submit new features or bug fixes through a `pull request
-<https://github.com/lab-cosmo/scikit-matter/pulls>`_.
+All examples are located in the ``examples`` directory in the root of the repository. To
+contribute a new example create a new ``.py`` file in one of the subdirectories. For
+writing the example/tutorial you can use another file for inspiration. Details on how to
+structure a Python script for Sphinx-Gallery are given in the `Sphinx-Gallery
+documentation <https://sphinx-gallery.github.io/stable/syntax.html>`.
+
+We encourage yoy to at least add one plot to your example to provide a nice image for
+the gallery on the website.
 
 
 Contributing Datasets
-#####################
+---------------------
 
 Have an example dataset that would fit into scikit-matter?
 
@@ -191,10 +205,3 @@ properly. It should look something like this:
 
 You're good to go! Time to submit a `pull request.
 <https://github.com/lab-cosmo/scikit-matter/pulls>`_
-
-
-License
-#######
-
-This project is distributed under the BSD-3-Clauses license. By contributing to it you
-agree to distribute your changes under the same license.

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -19,6 +19,10 @@ scikit-matter contains a toolbox of methods for unsupervised and supervised anal
 ML datasets, including the comparison, decomposition, and selection of features and
 samples.
 
+.. include:: ../../README.rst
+   :start-after: marker-issues
+   :end-before: marker-contributing
+
 .. toctree::
   :maxdepth: 1
   :caption: Contents:

--- a/docs/src/installation.rst
+++ b/docs/src/installation.rst
@@ -1,6 +1,6 @@
 .. include:: ../../README.rst
-   :start-after: installation
-   :end-before: contributors
+   :start-after: marker-installation
+   :end-before: marker-issues
 
 Install from source
 -------------------


### PR DESCRIPTION
Following the discussions in #185 here I try to improve the landing pages a bit more. This includes the `README.rst`, the landing page of the docs and the contributing page.

<!-- readthedocs-preview scikit-matter start -->
----
:books: Documentation preview :books:: https://scikit-matter--186.org.readthedocs.build/en/186/

<!-- readthedocs-preview scikit-matter end -->