### PR TITLE
Ignore rendered examples for linting

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -44,6 +44,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
     "sphinx_gallery.gen_gallery",
     "sphinx_toggleprompt",
 ]

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -42,9 +42,9 @@ release = skmatter.__version__
 # ones.
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
     "sphinx_gallery.gen_gallery",
-    "sphinx.ext.intersphinx",
     "sphinx_toggleprompt",
 ]
 
@@ -61,12 +61,12 @@ sphinx_gallery_conf = {
 # Configuration for intersphinx: refer to the Python standard library
 # and other packages
 intersphinx_mapping = {
-    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
     "matplotlib": ("https://matplotlib.org/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
-    "python": ("https://docs.python.org/3/", None),
-    "sklearn": ("https://scikit-learn.org/stable", None),
     "pandas": ("https://pandas.pydata.org/docs/", None),
+    "python": ("https://docs.python.org/3/", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
+    "sklearn": ("https://scikit-learn.org/stable", None),
 }
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,11 @@ envlist =
     lint
     tests
 
-lint_folders = "{toxinidir}/src" "{toxinidir}/tests" "{toxinidir}/docs/src/" "{toxinidir}/examples"
+lint_folders =
+    "{toxinidir}/src" \
+    "{toxinidir}/tests" \
+    "{toxinidir}/docs/src/" \
+    "{toxinidir}/examples"
 
 
 [testenv:tests]
@@ -43,7 +47,9 @@ commands =
     black --check --diff {[tox]lint_folders}
     blackdoc --check --diff {[tox]lint_folders}
     isort --check-only --diff {[tox]lint_folders}
-    sphinx-lint --enable line-too-long --max-line-length 88 {[tox]lint_folders} "{toxinidir}/README.rst"
+    sphinx-lint --enable line-too-long --max-line-length 88 \
+    -i "{toxinidir}/docs/src/examples" \
+    {[tox]lint_folders} "{toxinidir}/README.rst"
 
 [testenv:format]
 # Abuse tox to do actual formatting. Users can call `tox -e format` to run
@@ -68,6 +74,8 @@ commands = sphinx-build {posargs:-E} -W -b html docs/src docs/build/html
 
 [flake8]
 max_line_length = 88
+exclude =
+    docs/src/examples/
 per-file-ignores =
     # D205 and D400 are incompatible with the requirements of sphinx-gallery
     examples/**:D205, D400


### PR DESCRIPTION
Rendered examples of sphinx-gallery where also tested by the linters.

This unwanted behavior was causing errors locally of the linting is run after the docs where build.

<!-- readthedocs-preview scikit-matter start -->
----
:books: Documentation preview :books:: https://scikit-matter--188.org.readthedocs.build/en/188/

<!-- readthedocs-preview scikit-matter end -->