### PR TITLE
fixed small typo in PCovR class documentation

### DIFF
--- a/src/skmatter/decomposition/_pcovr.py
+++ b/src/skmatter/decomposition/_pcovr.py
@@ -51,7 +51,7 @@ class PCovR(_BasePCA, LinearModel):
 
     For all PCovR methods, it is strongly suggested that :math:`\mathbf{X}` and
     :math:`\mathbf{Y}` are centered and scaled to unit variance, otherwise the
-    results will change drastically near :math:`\alpha \to 0` and :math:`\alpha \to 0`.
+    results will change drastically near :math:`\alpha \to 0` and :math:`1-\alpha \to 0`.
     This can be done with the companion preprocessing classes, where
 
     >>> from skmatter.preprocessing import StandardFlexibleScaler as SFS

--- a/src/skmatter/decomposition/_pcovr.py
+++ b/src/skmatter/decomposition/_pcovr.py
@@ -51,7 +51,7 @@ class PCovR(_BasePCA, LinearModel):
 
     For all PCovR methods, it is strongly suggested that :math:`\mathbf{X}` and
     :math:`\mathbf{Y}` are centered and scaled to unit variance, otherwise the
-    results will change drastically near :math:`\alpha \to 0` and :math:`1-\alpha \to 0`.
+    results will change drastically near :math:`\alpha \to 0` and :math:`\alpha \to 1`.
     This can be done with the companion preprocessing classes, where
 
     >>> from skmatter.preprocessing import StandardFlexibleScaler as SFS


### PR DESCRIPTION
See #193, just a small typo that I fixed

<!-- readthedocs-preview scikit-matter start -->
----
:books: Documentation preview :books:: https://scikit-matter--194.org.readthedocs.build/en/194/

<!-- readthedocs-preview scikit-matter end -->