### PR TITLE
Fix/check estimator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__
 *.egg-info
 *.swp
 *.swo
+*DS_Store
 
 .tox/
 build/

--- a/src/skmatter/_selection.py
+++ b/src/skmatter/_selection.py
@@ -12,9 +12,8 @@ from scipy.linalg import eigh
 from scipy.sparse.linalg import eigsh
 from sklearn.base import BaseEstimator, MetaEstimatorMixin
 from sklearn.feature_selection._base import SelectorMixin
-from sklearn.utils import check_array, check_random_state, safe_mask
-from sklearn.utils._tags import _safe_tags
-from sklearn.utils.validation import check_is_fitted
+from sklearn.utils import check_array, check_random_state, check_X_y, safe_mask
+from sklearn.utils.validation import FLOAT_DTYPES, as_float_array, check_is_fitted
 
 from .utils import (
     X_orthogonalizer,
@@ -125,7 +124,6 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         -------
         self : object
         """
-        tags = self._get_tags()
 
         if self.selection_type == "feature":
             self._axis = 1
@@ -153,19 +151,26 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         else:
             params["ensure_min_samples"] = 2
 
-        if y is not None:
-            params["multi_output"] = True
-            X, y = self._validate_data(X, y, **params)
+        if hasattr(self, "mixing") or y is not None:
+            self._validate_data(X, y, **params)
+            X, y = check_X_y(X, y, multi_output=True)
 
             if len(y.shape) == 1:
                 # force y to have multi_output 2D format even when it's 1D, since
                 # many functions, most notably PCov routines, assume an array storage
                 # format, most notably to compute (y @ y.T)
                 y = y.reshape((len(y), 1))
+
         else:
             X = check_array(X, **params)
 
+        if self.full and self.score_threshold is not None:
+            raise ValueError(
+                "You cannot specify both `score_threshold` and `full=True`."
+            )
+
         n_to_select_from = X.shape[self._axis]
+
         self.n_samples_in_, self.n_features_in_ = X.shape
 
         self.n_samples_in_, self.n_features_in_ = X.shape
@@ -244,8 +249,10 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
             The selected subset of the input.
         """
 
-        if len(X.shape) == 1:
-            X = X.reshape(-1, 1)
+        if self.axis == 0:
+            raise ValueError(
+                "Transform is not currently supported for sample selection."
+            )
 
         mask = self.get_support()
 
@@ -518,7 +525,7 @@ class _CUR(GreedySelector):
         features and computes their initial importance score.
         """
 
-        self.X_current_ = X.copy()
+        self.X_current_ = as_float_array(X.copy())
         self.pi_ = self._compute_pi(self.X_current_)
 
         super()._init_greedy_search(X, y, n_to_select)

--- a/src/skmatter/_selection.py
+++ b/src/skmatter/_selection.py
@@ -145,7 +145,7 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         params = dict(ensure_min_samples=2, ensure_min_features=2, dtype=FLOAT_DTYPES)
 
         if hasattr(self, "mixing") or y is not None:
-            self._validate_data(X, y, **params)
+            X, y = self._validate_data(X, y, **params)
             X, y = check_X_y(X, y, multi_output=True)
 
             if len(y.shape) == 1:

--- a/src/skmatter/_selection.py
+++ b/src/skmatter/_selection.py
@@ -169,13 +169,7 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
                 "You cannot specify both `score_threshold` and `full=True`."
             )
 
-        if self.progress_bar is True:
-            self.report_progress_ = get_progress_bar()
-        elif self.progress_bar is False:
-            self.report_progress_ = no_progress_bar
-
         n_to_select_from = X.shape[self._axis]
-
         self.n_samples_in_, self.n_features_in_ = X.shape
 
         self.n_samples_in_, self.n_features_in_ = X.shape

--- a/src/skmatter/_selection.py
+++ b/src/skmatter/_selection.py
@@ -166,7 +166,6 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
             X = check_array(X, **params)
 
         n_to_select_from = X.shape[self._axis]
-
         self.n_samples_in_, self.n_features_in_ = X.shape
 
         self.n_samples_in_, self.n_features_in_ = X.shape

--- a/src/skmatter/_selection.py
+++ b/src/skmatter/_selection.py
@@ -39,7 +39,7 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
 
     selection_type : str, {'feature', 'sample'}
         whether to choose a subset of columns ('feature') or rows ('sample').
-        Stored in :py:attr:`self._axis_name` (as text) and :py:attr:`self._axis`
+        Stored in :py:attr:`self.axis_name` (as text) and :py:attr:`self.axis`
         (as 0 or 1 for 'sample' or 'feature', respectively).
 
     n_to_select : int or float, default=None
@@ -71,6 +71,8 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
 
     random_state: int or RandomState instance, default=0
 
+    axis: [0,1] axis over which we are doing selection
+
     Attributes
     ----------
     n_selected_ : int
@@ -93,8 +95,24 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         progress_bar=False,
         full=False,
         random_state=0,
+        axis=None,
     ):
-        self.selection_type = selection_type
+        if selection_type is not None and axis is None:
+            self.selection_type = selection_type
+            if selection_type == "feature":
+                self.axis = 1
+            elif selection_type == "sample":
+                self.axis = 0
+            else:
+                raise ValueError("Only feature and sample selection supported.")
+        elif axis is not None:
+            if axis in [0, 1]:
+                self.axis = axis
+                self.selection_type = ["sample", "feature"][axis]
+            else:
+                raise ValueError(
+                    "Only feature (axis=1) and sample (axis=0) selection supported."
+                )
         self.n_to_select = n_to_select
         self.score_threshold = score_threshold
         self.score_threshold_type = score_threshold_type
@@ -127,13 +145,6 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         """
         tags = self._get_tags()
 
-        if self.selection_type == "feature":
-            self._axis = 1
-        elif self.selection_type == "sample":
-            self._axis = 0
-        else:
-            raise ValueError("Only feature and sample selection supported.")
-
         if self.full and self.score_threshold is not None:
             raise ValueError(
                 "You cannot specify both `score_threshold` and `full=True`."
@@ -148,7 +159,7 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
             accept_sparse="csc",
             force_all_finite=not tags.get("allow_nan", True),
         )
-        if self._axis == 1:
+        if self.axis == 1:
             params["ensure_min_features"] = 2
         else:
             params["ensure_min_samples"] = 2
@@ -165,7 +176,8 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         else:
             X = check_array(X, **params)
 
-        n_to_select_from = X.shape[self._axis]
+        n_to_select_from = X.shape[self.axis]
+        self.n_samples_in_, self.n_features_in_ = X.shape
 
         self.n_samples_in_, self.n_features_in_ = X.shape
 
@@ -215,7 +227,7 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
                     stacklevel=1,
                 )
                 self.X_selected_ = np.take(
-                    self.X_selected_, np.arange(self.n_selected_), axis=self._axis
+                    self.X_selected_, np.arange(self.n_selected_), axis=self.axis
                 )
 
                 if hasattr(self, "y_selected_"):
@@ -256,7 +268,7 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
             accept_sparse="csr",
             force_all_finite=not _safe_tags(self, key="allow_nan"),
             reset=False,
-            ensure_2d=self._axis,
+            ensure_2d=self.axis,
         )
 
         if self._axis == 1:
@@ -327,11 +339,11 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         self.first_score_ = None
 
         sel_shape = list(X.shape)
-        sel_shape[self._axis] = n_to_select
+        sel_shape[self.axis] = n_to_select
 
         self.X_selected_ = np.zeros(sel_shape, float)
 
-        if y is not None and self._axis == 0:
+        if y is not None and self.axis == 0:
             self.y_selected_ = np.zeros(
                 (n_to_select, y.reshape(y.shape[0], -1).shape[1]), float
             )
@@ -341,7 +353,7 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         """Continues the search. Prepares an array to store the selected features."""
 
         n_pad = [(0, 0), (0, 0)]
-        n_pad[self._axis] = (0, n_to_select - self.n_selected_)
+        n_pad[self.axis] = (0, n_to_select - self.n_selected_)
 
         self.X_selected_ = np.pad(
             self.X_selected_,
@@ -385,13 +397,13 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         Saves the most recently selected feature and increments the feature counter
         """
 
-        if self._axis == 1:
+        if self.axis == 1:
             self.X_selected_[:, self.n_selected_] = np.take(
-                X, last_selected, axis=self._axis
+                X, last_selected, axis=self.axis
             )
         else:
             self.X_selected_[self.n_selected_] = np.take(
-                X, last_selected, axis=self._axis
+                X, last_selected, axis=self.axis
             )
 
             if hasattr(self, "y_selected_"):
@@ -420,7 +432,7 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
 
     def _postprocess(self, X, y):
         """Post-process X and / or y when selection is finished"""
-        self.support_ = np.full(X.shape[self._axis], False)
+        self.support_ = np.full(X.shape[self.axis], False)
         self.support_[self.selected_idx_] = True
 
     def _more_tags(self):
@@ -531,7 +543,7 @@ class _CUR(GreedySelector):
 
         for c in self.selected_idx_:
             if self.recompute_every != 0 and (
-                np.linalg.norm(np.take(self.X_current_, [c], axis=self._axis))
+                np.linalg.norm(np.take(self.X_current_, [c], axis=self.axis))
                 > self.tolerance
             ):
                 self._orthogonalize(last_selected=c)
@@ -575,7 +587,7 @@ class _CUR(GreedySelector):
             :math:`\\pi` importance for the given samples or features
         """
 
-        if self._axis == 0:
+        if self.axis == 0:
             U, _, _ = scipy.sparse.linalg.svds(X, k=self.k, return_singular_vectors="u")
             U = np.real(U)
             new_pi = (U[:, : self.k] ** 2.0).sum(axis=1)
@@ -604,7 +616,7 @@ class _CUR(GreedySelector):
         self.pi_[last_selected] = 0.0
 
     def _orthogonalize(self, last_selected):
-        if self._axis == 1:
+        if self.axis == 1:
             self.X_current_ = X_orthogonalizer(
                 x1=self.X_current_, c=last_selected, tol=self.tolerance
             )
@@ -731,7 +743,7 @@ class _PCovCUR(GreedySelector):
 
         for c in self.selected_idx_:
             if self.recompute_every != 0 and (
-                np.linalg.norm(np.take(self.X_current_, [c], axis=self._axis))
+                np.linalg.norm(np.take(self.X_current_, [c], axis=self.axis))
                 > self.tolerance
             ):
                 self._orthogonalize(last_selected=c)
@@ -799,7 +811,7 @@ class _PCovCUR(GreedySelector):
             :math:`\pi` importance for the given samples or features
         """
 
-        if self._axis == 0:
+        if self.axis == 0:
             pcovr_distance = pcovr_kernel(
                 self.mixing,
                 X,
@@ -824,7 +836,7 @@ class _PCovCUR(GreedySelector):
         return pi
 
     def _orthogonalize(self, last_selected):
-        if self._axis == 1:
+        if self.axis == 1:
             self.X_current_ = X_orthogonalizer(
                 x1=self.X_current_, c=last_selected, tol=self.tolerance
             )
@@ -833,7 +845,7 @@ class _PCovCUR(GreedySelector):
                 x1=self.X_current_.T, c=last_selected, tol=self.tolerance
             ).T
         if self.y_current_ is not None:
-            if self._axis == 1:
+            if self.axis == 1:
                 self.y_current_ = Y_feature_orthogonalizer(
                     self.y_current_, X=self.X_selected_, tol=self.tolerance
                 )
@@ -959,13 +971,13 @@ class _FPS(GreedySelector):
 
         super()._init_greedy_search(X, y, n_to_select)
 
-        self.norms_ = (X**2).sum(axis=abs(self._axis - 1))
-        self.haussdorf_ = np.full(X.shape[self._axis], np.inf)
-        self.haussdorf_at_select_ = np.full(X.shape[self._axis], np.inf)
+        self.norms_ = (X**2).sum(axis=abs(self.axis - 1))
+        self.haussdorf_ = np.full(X.shape[self.axis], np.inf)
+        self.haussdorf_at_select_ = np.full(X.shape[self.axis], np.inf)
 
         if self.initialize == "random":
             random_state = check_random_state(self.random_state)
-            initialize = random_state.randint(X.shape[self._axis])
+            initialize = random_state.randint(X.shape[self.axis])
             self.selected_idx_[0] = initialize
             self._update_post_selection(X, y, self.selected_idx_[0])
         elif isinstance(self.initialize, numbers.Integral):
@@ -985,7 +997,7 @@ class _FPS(GreedySelector):
         self.haussdorf_at_select_[last_selected] = self.haussdorf_[last_selected]
 
         # distances of all points to the new point
-        if self._axis == 1:
+        if self.axis == 1:
             new_dist = (
                 self.norms_ + self.norms_[last_selected] - 2 * X[:, last_selected].T @ X
             )
@@ -1115,7 +1127,7 @@ class _PCovFPS(GreedySelector):
 
         super()._init_greedy_search(X, y, n_to_select)
 
-        if self._axis == 1:
+        if self.axis == 1:
             self.pcovr_distance_ = pcovr_covariance(mixing=self.mixing, X=X, Y=y)
         else:
             self.pcovr_distance_ = pcovr_kernel(mixing=self.mixing, X=X, Y=y)
@@ -1124,15 +1136,15 @@ class _PCovFPS(GreedySelector):
 
         if self.initialize == "random":
             random_state = check_random_state(self.random_state)
-            initialize = random_state.randint(X.shape[self._axis])
+            initialize = random_state.randint(X.shape[self.axis])
         elif isinstance(self.initialize, numbers.Integral):
             initialize = self.initialize
         else:
             raise ValueError("Invalid value of the initialize parameter")
 
         self.selected_idx_[0] = initialize
-        self.haussdorf_ = np.full(X.shape[self._axis], np.inf)
-        self.haussdorf_at_select_ = np.full(X.shape[self._axis], np.inf)
+        self.haussdorf_ = np.full(X.shape[self.axis], np.inf)
+        self.haussdorf_at_select_ = np.full(X.shape[self.axis], np.inf)
         self._update_post_selection(X, y, self.selected_idx_[0])
 
     def _update_haussdorf(self, X, y, last_selected):
@@ -1142,7 +1154,7 @@ class _PCovFPS(GreedySelector):
         new_dist = (
             self.norms_
             + self.norms_[last_selected]
-            - 2 * np.take(self.pcovr_distance_, last_selected, axis=self._axis)
+            - 2 * np.take(self.pcovr_distance_, last_selected, axis=self.axis)
         )
 
         # update in-place the Haussdorf distance list

--- a/src/skmatter/_selection.py
+++ b/src/skmatter/_selection.py
@@ -39,7 +39,7 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
 
     selection_type : str, {'feature', 'sample'}
         whether to choose a subset of columns ('feature') or rows ('sample').
-        Stored in :py:attr:`self.axis_name` (as text) and :py:attr:`self.axis`
+        Stored in :py:attr:`self._axis_name` (as text) and :py:attr:`self._axis`
         (as 0 or 1 for 'sample' or 'feature', respectively).
 
     n_to_select : int or float, default=None
@@ -71,8 +71,6 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
 
     random_state: int or RandomState instance, default=0
 
-    axis: [0,1] axis over which we are doing selection
-
     Attributes
     ----------
     n_selected_ : int
@@ -95,24 +93,8 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         progress_bar=False,
         full=False,
         random_state=0,
-        axis=None,
     ):
-        if selection_type is not None and axis is None:
-            self.selection_type = selection_type
-            if selection_type == "feature":
-                self.axis = 1
-            elif selection_type == "sample":
-                self.axis = 0
-            else:
-                raise ValueError("Only feature and sample selection supported.")
-        elif axis is not None:
-            if axis in [0, 1]:
-                self.axis = axis
-                self.selection_type = ["sample", "feature"][axis]
-            else:
-                raise ValueError(
-                    "Only feature (axis=1) and sample (axis=0) selection supported."
-                )
+        self.selection_type = selection_type
         self.n_to_select = n_to_select
         self.score_threshold = score_threshold
         self.score_threshold_type = score_threshold_type
@@ -145,6 +127,13 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         """
         tags = self._get_tags()
 
+        if self.selection_type == "feature":
+            self._axis = 1
+        elif self.selection_type == "sample":
+            self._axis = 0
+        else:
+            raise ValueError("Only feature and sample selection supported.")
+
         if self.full and self.score_threshold is not None:
             raise ValueError(
                 "You cannot specify both `score_threshold` and `full=True`."
@@ -159,7 +148,7 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
             accept_sparse="csc",
             force_all_finite=not tags.get("allow_nan", True),
         )
-        if self.axis == 1:
+        if self._axis == 1:
             params["ensure_min_features"] = 2
         else:
             params["ensure_min_samples"] = 2
@@ -176,7 +165,8 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         else:
             X = check_array(X, **params)
 
-        n_to_select_from = X.shape[self.axis]
+        n_to_select_from = X.shape[self._axis]
+
         self.n_samples_in_, self.n_features_in_ = X.shape
 
         self.n_samples_in_, self.n_features_in_ = X.shape
@@ -227,7 +217,7 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
                     stacklevel=1,
                 )
                 self.X_selected_ = np.take(
-                    self.X_selected_, np.arange(self.n_selected_), axis=self.axis
+                    self.X_selected_, np.arange(self.n_selected_), axis=self._axis
                 )
 
                 if hasattr(self, "y_selected_"):
@@ -268,7 +258,7 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
             accept_sparse="csr",
             force_all_finite=not _safe_tags(self, key="allow_nan"),
             reset=False,
-            ensure_2d=self.axis,
+            ensure_2d=self._axis,
         )
 
         if self._axis == 1:
@@ -339,11 +329,11 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         self.first_score_ = None
 
         sel_shape = list(X.shape)
-        sel_shape[self.axis] = n_to_select
+        sel_shape[self._axis] = n_to_select
 
         self.X_selected_ = np.zeros(sel_shape, float)
 
-        if y is not None and self.axis == 0:
+        if y is not None and self._axis == 0:
             self.y_selected_ = np.zeros(
                 (n_to_select, y.reshape(y.shape[0], -1).shape[1]), float
             )
@@ -353,7 +343,7 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         """Continues the search. Prepares an array to store the selected features."""
 
         n_pad = [(0, 0), (0, 0)]
-        n_pad[self.axis] = (0, n_to_select - self.n_selected_)
+        n_pad[self._axis] = (0, n_to_select - self.n_selected_)
 
         self.X_selected_ = np.pad(
             self.X_selected_,
@@ -397,13 +387,13 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         Saves the most recently selected feature and increments the feature counter
         """
 
-        if self.axis == 1:
+        if self._axis == 1:
             self.X_selected_[:, self.n_selected_] = np.take(
-                X, last_selected, axis=self.axis
+                X, last_selected, axis=self._axis
             )
         else:
             self.X_selected_[self.n_selected_] = np.take(
-                X, last_selected, axis=self.axis
+                X, last_selected, axis=self._axis
             )
 
             if hasattr(self, "y_selected_"):
@@ -432,7 +422,7 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
 
     def _postprocess(self, X, y):
         """Post-process X and / or y when selection is finished"""
-        self.support_ = np.full(X.shape[self.axis], False)
+        self.support_ = np.full(X.shape[self._axis], False)
         self.support_[self.selected_idx_] = True
 
     def _more_tags(self):
@@ -543,7 +533,7 @@ class _CUR(GreedySelector):
 
         for c in self.selected_idx_:
             if self.recompute_every != 0 and (
-                np.linalg.norm(np.take(self.X_current_, [c], axis=self.axis))
+                np.linalg.norm(np.take(self.X_current_, [c], axis=self._axis))
                 > self.tolerance
             ):
                 self._orthogonalize(last_selected=c)
@@ -587,7 +577,7 @@ class _CUR(GreedySelector):
             :math:`\\pi` importance for the given samples or features
         """
 
-        if self.axis == 0:
+        if self._axis == 0:
             U, _, _ = scipy.sparse.linalg.svds(X, k=self.k, return_singular_vectors="u")
             U = np.real(U)
             new_pi = (U[:, : self.k] ** 2.0).sum(axis=1)
@@ -616,7 +606,7 @@ class _CUR(GreedySelector):
         self.pi_[last_selected] = 0.0
 
     def _orthogonalize(self, last_selected):
-        if self.axis == 1:
+        if self._axis == 1:
             self.X_current_ = X_orthogonalizer(
                 x1=self.X_current_, c=last_selected, tol=self.tolerance
             )
@@ -743,7 +733,7 @@ class _PCovCUR(GreedySelector):
 
         for c in self.selected_idx_:
             if self.recompute_every != 0 and (
-                np.linalg.norm(np.take(self.X_current_, [c], axis=self.axis))
+                np.linalg.norm(np.take(self.X_current_, [c], axis=self._axis))
                 > self.tolerance
             ):
                 self._orthogonalize(last_selected=c)
@@ -811,7 +801,7 @@ class _PCovCUR(GreedySelector):
             :math:`\pi` importance for the given samples or features
         """
 
-        if self.axis == 0:
+        if self._axis == 0:
             pcovr_distance = pcovr_kernel(
                 self.mixing,
                 X,
@@ -836,7 +826,7 @@ class _PCovCUR(GreedySelector):
         return pi
 
     def _orthogonalize(self, last_selected):
-        if self.axis == 1:
+        if self._axis == 1:
             self.X_current_ = X_orthogonalizer(
                 x1=self.X_current_, c=last_selected, tol=self.tolerance
             )
@@ -845,7 +835,7 @@ class _PCovCUR(GreedySelector):
                 x1=self.X_current_.T, c=last_selected, tol=self.tolerance
             ).T
         if self.y_current_ is not None:
-            if self.axis == 1:
+            if self._axis == 1:
                 self.y_current_ = Y_feature_orthogonalizer(
                     self.y_current_, X=self.X_selected_, tol=self.tolerance
                 )
@@ -971,13 +961,13 @@ class _FPS(GreedySelector):
 
         super()._init_greedy_search(X, y, n_to_select)
 
-        self.norms_ = (X**2).sum(axis=abs(self.axis - 1))
-        self.haussdorf_ = np.full(X.shape[self.axis], np.inf)
-        self.haussdorf_at_select_ = np.full(X.shape[self.axis], np.inf)
+        self.norms_ = (X**2).sum(axis=abs(self._axis - 1))
+        self.haussdorf_ = np.full(X.shape[self._axis], np.inf)
+        self.haussdorf_at_select_ = np.full(X.shape[self._axis], np.inf)
 
         if self.initialize == "random":
             random_state = check_random_state(self.random_state)
-            initialize = random_state.randint(X.shape[self.axis])
+            initialize = random_state.randint(X.shape[self._axis])
             self.selected_idx_[0] = initialize
             self._update_post_selection(X, y, self.selected_idx_[0])
         elif isinstance(self.initialize, numbers.Integral):
@@ -997,7 +987,7 @@ class _FPS(GreedySelector):
         self.haussdorf_at_select_[last_selected] = self.haussdorf_[last_selected]
 
         # distances of all points to the new point
-        if self.axis == 1:
+        if self._axis == 1:
             new_dist = (
                 self.norms_ + self.norms_[last_selected] - 2 * X[:, last_selected].T @ X
             )
@@ -1127,7 +1117,7 @@ class _PCovFPS(GreedySelector):
 
         super()._init_greedy_search(X, y, n_to_select)
 
-        if self.axis == 1:
+        if self._axis == 1:
             self.pcovr_distance_ = pcovr_covariance(mixing=self.mixing, X=X, Y=y)
         else:
             self.pcovr_distance_ = pcovr_kernel(mixing=self.mixing, X=X, Y=y)
@@ -1136,15 +1126,15 @@ class _PCovFPS(GreedySelector):
 
         if self.initialize == "random":
             random_state = check_random_state(self.random_state)
-            initialize = random_state.randint(X.shape[self.axis])
+            initialize = random_state.randint(X.shape[self._axis])
         elif isinstance(self.initialize, numbers.Integral):
             initialize = self.initialize
         else:
             raise ValueError("Invalid value of the initialize parameter")
 
         self.selected_idx_[0] = initialize
-        self.haussdorf_ = np.full(X.shape[self.axis], np.inf)
-        self.haussdorf_at_select_ = np.full(X.shape[self.axis], np.inf)
+        self.haussdorf_ = np.full(X.shape[self._axis], np.inf)
+        self.haussdorf_at_select_ = np.full(X.shape[self._axis], np.inf)
         self._update_post_selection(X, y, self.selected_idx_[0])
 
     def _update_haussdorf(self, X, y, last_selected):
@@ -1154,7 +1144,7 @@ class _PCovFPS(GreedySelector):
         new_dist = (
             self.norms_
             + self.norms_[last_selected]
-            - 2 * np.take(self.pcovr_distance_, last_selected, axis=self.axis)
+            - 2 * np.take(self.pcovr_distance_, last_selected, axis=self._axis)
         )
 
         # update in-place the Haussdorf distance list

--- a/src/skmatter/_selection.py
+++ b/src/skmatter/_selection.py
@@ -142,14 +142,7 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         elif self.progress_bar is False:
             self.report_progress_ = no_progress_bar
 
-        params = dict(
-            accept_sparse="csc",
-            force_all_finite=not tags.get("allow_nan", True),
-        )
-        if self._axis == 1:
-            params["ensure_min_features"] = 2
-        else:
-            params["ensure_min_samples"] = 2
+        params = dict(ensure_min_samples=2, ensure_min_features=2, dtype=FLOAT_DTYPES)
 
         if hasattr(self, "mixing") or y is not None:
             self._validate_data(X, y, **params)
@@ -263,7 +256,7 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
             else:
                 X = X.reshape(1, -1)
 
-        if len(mask) != X.shape[self.axis]:
+        if len(mask) != X.shape[self._axis]:
             raise ValueError(
                 "X has a different shape than during fitting. Reshape your data."
             )

--- a/src/skmatter/_selection.py
+++ b/src/skmatter/_selection.py
@@ -241,7 +241,9 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
             The selected subset of the input.
         """
 
-        if self.axis == 0:
+        check_is_fitted(self, ["_axis", "selected_idx_", "n_selected_"])
+
+        if self._axis == 0:
             raise ValueError(
                 "Transform is not currently supported for sample selection."
             )
@@ -251,7 +253,7 @@ class GreedySelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         X = check_array(X)
 
         if len(X.shape) == 1:
-            if self.axis == 0:
+            if self._axis == 0:
                 X = X.reshape(-1, 1)
             else:
                 X = X.reshape(1, -1)

--- a/src/skmatter/decomposition/_pcovr.py
+++ b/src/skmatter/decomposition/_pcovr.py
@@ -130,6 +130,8 @@ class PCovR(_BasePCA, LinearModel):
          Used when the 'arpack' or 'randomized' solvers are used. Pass an int
          for reproducible results across multiple function calls.
 
+    whiten : boolean, deprecated
+
     Attributes
     ----------
 
@@ -202,12 +204,13 @@ class PCovR(_BasePCA, LinearModel):
         regressor=None,
         iterated_power="auto",
         random_state=None,
+        whiten=False,
     ):
         self.mixing = mixing
         self.n_components = n_components
         self.space = space
 
-        self.whiten = False
+        self.whiten = whiten
         self.svd_solver = svd_solver
         self.tol = tol
         self.iterated_power = iterated_power

--- a/src/skmatter/linear_model/_ridge.py
+++ b/src/skmatter/linear_model/_ridge.py
@@ -144,7 +144,6 @@ class RidgeRegression2FoldCV(BaseEstimator, MultiOutputMixin, RegressorMixin):
             )
 
         X, y = self._validate_data(X, y, y_numeric=True, multi_output=True)
-
         self.n_samples_in_, self.n_features_in_ = X.shape
 
         # check_scoring uses estimators scoring function if the scorer is None, this is

--- a/src/skmatter/linear_model/_ridge.py
+++ b/src/skmatter/linear_model/_ridge.py
@@ -1,11 +1,13 @@
 import numpy as np
 from joblib import Parallel, delayed
-from sklearn.base import MultiOutputMixin, RegressorMixin
+from sklearn.base import BaseEstimator, MultiOutputMixin, RegressorMixin
 from sklearn.metrics import check_scoring
 from sklearn.model_selection import KFold
+from sklearn.utils import check_array
+from sklearn.utils.validation import check_is_fitted
 
 
-class RidgeRegression2FoldCV(MultiOutputMixin, RegressorMixin):
+class RidgeRegression2FoldCV(BaseEstimator, MultiOutputMixin, RegressorMixin):
     r"""Ridge regression with an efficient 2-fold cross-validation method using the SVD
     solver.
 
@@ -110,6 +112,9 @@ class RidgeRegression2FoldCV(MultiOutputMixin, RegressorMixin):
         self.shuffle = shuffle
         self.n_jobs = n_jobs
 
+    def _more_tags(self):
+        return {"multioutput_only": True}
+
     def fit(self, X, y):
         """
         Parameters
@@ -138,6 +143,8 @@ class RidgeRegression2FoldCV(MultiOutputMixin, RegressorMixin):
                 "[0,1)"
             )
 
+        X, y = self._validate_data(X, y, y_numeric=True, multi_output=True)
+
         self.n_samples_in_, self.n_features_in_ = X.shape
 
         # check_scoring uses estimators scoring function if the scorer is None, this is
@@ -164,6 +171,11 @@ class RidgeRegression2FoldCV(MultiOutputMixin, RegressorMixin):
             Training data, where n_samples is the number of samples
             and n_features is the number of features.
         """
+
+        X = check_array(X)
+
+        check_is_fitted(self, ["coef_"])
+
         return X @ self.coef_.T
 
     def _2fold_cv(self, X, y, fold1_idx, fold2_idx, scorer):

--- a/src/skmatter/metrics/_reconstruction_measures.py
+++ b/src/skmatter/metrics/_reconstruction_measures.py
@@ -445,7 +445,7 @@ def pointwise_local_reconstruction_error(
 
     scaler.fit(X_train)
     X_train = scaler.transform(X_train)
-    X_test = scaler.transform(X_test)
+    X_test = scaler.transform(X_test).astype(X_train.dtype)
     scaler.fit(Y_train)
     Y_train = scaler.transform(Y_train)
     Y_test = scaler.transform(Y_test)

--- a/src/skmatter/preprocessing/_data.py
+++ b/src/skmatter/preprocessing/_data.py
@@ -142,6 +142,7 @@ class StandardFlexibleScaler(TransformerMixin, BaseEstimator):
             dtype=FLOAT_DTYPES,
             ensure_min_samples=2,
         )
+
         self.n_samples_in_, self.n_features_in_ = X.shape
 
         if sample_weight is not None:

--- a/src/skmatter/preprocessing/_data.py
+++ b/src/skmatter/preprocessing/_data.py
@@ -142,7 +142,6 @@ class StandardFlexibleScaler(TransformerMixin, BaseEstimator):
             dtype=FLOAT_DTYPES,
             ensure_min_samples=2,
         )
-
         self.n_samples_in_, self.n_features_in_ = X.shape
 
         if sample_weight is not None:

--- a/src/skmatter/sample_selection/_voronoi_fps.py
+++ b/src/skmatter/sample_selection/_voronoi_fps.py
@@ -195,19 +195,19 @@ class VoronoiFPS(GreedySelector):
 
         super()._init_greedy_search(X, y, n_to_select)
 
-        self.norms_ = (X**2).sum(axis=abs(self._axis - 1))
+        self.norms_ = (X**2).sum(axis=abs(self.axis - 1))
 
         if self.initialize == "random":
             random_state = check_random_state(self.random_state)
-            initialize = random_state.randint(X.shape[self._axis])
+            initialize = random_state.randint(X.shape[self.axis])
         elif isinstance(self.initialize, numbers.Integral):
             initialize = self.initialize
         else:
             raise ValueError("Invalid value of the initialize parameter")
 
         self.selected_idx_[0] = initialize
-        self.haussdorf_ = np.full(X.shape[self._axis], np.inf)
-        self.haussdorf_at_select_ = np.full(X.shape[self._axis], np.inf)
+        self.haussdorf_ = np.full(X.shape[self.axis], np.inf)
+        self.haussdorf_at_select_ = np.full(X.shape[self.axis], np.inf)
         self._update_post_selection(X, y, self.selected_idx_[0])
 
     def _continue_greedy_search(self, X, y, n_to_select):

--- a/src/skmatter/sample_selection/_voronoi_fps.py
+++ b/src/skmatter/sample_selection/_voronoi_fps.py
@@ -195,19 +195,19 @@ class VoronoiFPS(GreedySelector):
 
         super()._init_greedy_search(X, y, n_to_select)
 
-        self.norms_ = (X**2).sum(axis=abs(self.axis - 1))
+        self.norms_ = (X**2).sum(axis=abs(self._axis - 1))
 
         if self.initialize == "random":
             random_state = check_random_state(self.random_state)
-            initialize = random_state.randint(X.shape[self.axis])
+            initialize = random_state.randint(X.shape[self._axis])
         elif isinstance(self.initialize, numbers.Integral):
             initialize = self.initialize
         else:
             raise ValueError("Invalid value of the initialize parameter")
 
         self.selected_idx_[0] = initialize
-        self.haussdorf_ = np.full(X.shape[self.axis], np.inf)
-        self.haussdorf_at_select_ = np.full(X.shape[self.axis], np.inf)
+        self.haussdorf_ = np.full(X.shape[self._axis], np.inf)
+        self.haussdorf_at_select_ = np.full(X.shape[self._axis], np.inf)
         self._update_post_selection(X, y, self.selected_idx_[0])
 
     def _continue_greedy_search(self, X, y, n_to_select):

--- a/src/skmatter/utils/_orthogonalizers.py
+++ b/src/skmatter/utils/_orthogonalizers.py
@@ -56,9 +56,9 @@ def X_orthogonalizer(x1, c=None, x2=None, tol=1e-12, copy=False):
         if np.linalg.norm(col) < tol:
             warnings.warn("Column vector contains only zeros.", stacklevel=1)
         else:
-            col /= np.linalg.norm(col, axis=0)
+            col = np.divide(col, np.linalg.norm(col, axis=0))
 
-        xnew -= col @ (col.T @ xnew)
+        xnew -= (col @ (col.T @ xnew)).astype(xnew.dtype)
 
     return xnew
 

--- a/src/skmatter/utils/_pcovr_utils.py
+++ b/src/skmatter/utils/_pcovr_utils.py
@@ -186,7 +186,7 @@ def pcovr_covariance(
         C_Y = C_Y.reshape((C.shape[0], -1))
         C_Y = np.real(C_Y)
 
-        C += (1 - mixing) * C_Y @ C_Y.T
+        C += (1 - mixing) * np.array(C_Y @ C_Y.T, dtype=np.float64)
 
     if mixing > 0:
         C += (mixing) * (X.T @ X)

--- a/tests/test_check_estimators.py
+++ b/tests/test_check_estimators.py
@@ -1,0 +1,26 @@
+from sklearn.utils.estimator_checks import parametrize_with_checks
+
+from skmatter.decomposition import KernelPCovR, PCovR
+from skmatter.feature_selection import CUR as fCUR
+from skmatter.feature_selection import FPS as fFPS
+from skmatter.feature_selection import PCovCUR as fPCovCUR
+from skmatter.feature_selection import PCovFPS as fPCovFPS
+from skmatter.linear_model import RidgeRegression2FoldCV  # OrthogonalRegression,
+from skmatter.preprocessing import KernelNormalizer, StandardFlexibleScaler
+
+
+@parametrize_with_checks(
+    [
+        KernelPCovR(mixing=0.5),
+        PCovR(mixing=0.5),
+        fCUR(),
+        fFPS(),
+        fPCovCUR(),
+        fPCovFPS(),
+        RidgeRegression2FoldCV(),
+        KernelNormalizer(),
+        StandardFlexibleScaler(),
+    ]
+)
+def test_sklearn_compatible_estimator(estimator, check):
+    check(estimator)

--- a/tests/test_feature_simple_cur.py
+++ b/tests/test_feature_simple_cur.py
@@ -4,12 +4,13 @@ import numpy as np
 from sklearn import exceptions
 
 from skmatter.datasets import load_csd_1000r as load
-from skmatter.feature_selection import CUR
+from skmatter.feature_selection import CUR, FPS
 
 
 class TestCUR(unittest.TestCase):
     def setUp(self):
         self.X, _ = load(return_X_y=True)
+        self.X = FPS(n_to_select=10).fit(self.X).transform(self.X)
 
     def test_bad_transform(self):
         selector = CUR(n_to_select=2)

--- a/tests/test_greedy_selector.py
+++ b/tests/test_greedy_selector.py
@@ -61,9 +61,11 @@ class TestGreedy(unittest.TestCase):
 
     def test_bad_y(self):
         self.X, self.Y = get_dataset(return_X_y=True)
+        Y = self.Y[:2]
+        print(self.X.shape, Y.shape)
         selector = GreedyTester(n_to_select=2)
         with self.assertRaises(ValueError):
-            selector.fit(X=self.X, y=self.Y[:2])
+            selector.fit(X=self.X, y=Y)
 
     def test_bad_transform(self):
         selector = GreedyTester(n_to_select=2)
@@ -130,6 +132,7 @@ class TestGreedy(unittest.TestCase):
         )
 
         X = X.reshape(1, -1)
+
         with self.assertRaises(ValueError) as cm:
             selector_sample.fit(X)
         self.assertEqual(
@@ -138,6 +141,7 @@ class TestGreedy(unittest.TestCase):
             "required.",
         )
 
+>>>>>>> cdefe67 (Edits re: alex)
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_greedy_selector.py
+++ b/tests/test_greedy_selector.py
@@ -74,8 +74,7 @@ class TestGreedy(unittest.TestCase):
             _ = selector.transform(self.X[:, :3])
         self.assertEqual(
             str(cm.exception),
-            "X has 3 features, but GreedyTester is expecting {} features"
-            " as input.".format(self.X.shape[1]),
+            "X has a different shape than during fitting. Reshape your data.",
         )
 
     def test_no_nfeatures(self):
@@ -122,13 +121,12 @@ class TestGreedy(unittest.TestCase):
         X = np.array([1, 2, 3, 4, 5]).reshape(-1, 1)
         selector_sample = GreedyTester(selection_type="sample")
         selector_feature = GreedyTester(selection_type="feature")
-
         with self.assertRaises(ValueError) as cm:
             selector_feature.fit(X)
         self.assertEqual(
             str(cm.exception),
-            f"Found array with 1 feature(s) (shape={X.shape}) while a minimum of 2 is "
-            "required.",
+            f"Found array with 1 feature(s) (shape={X.shape})"
+            " while a minimum of 2 is required.",
         )
 
         X = X.reshape(1, -1)
@@ -141,7 +139,6 @@ class TestGreedy(unittest.TestCase):
             "required.",
         )
 
->>>>>>> cdefe67 (Edits re: alex)
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_greedy_selector.py
+++ b/tests/test_greedy_selector.py
@@ -139,7 +139,6 @@ class TestGreedy(unittest.TestCase):
             "required.",
         )
 
->>>>>>> cdefe67 (Edits re: alex)
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_greedy_selector.py
+++ b/tests/test_greedy_selector.py
@@ -139,6 +139,7 @@ class TestGreedy(unittest.TestCase):
             "required.",
         )
 
+>>>>>>> cdefe67 (Edits re: alex)
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_greedy_selector.py
+++ b/tests/test_greedy_selector.py
@@ -62,7 +62,6 @@ class TestGreedy(unittest.TestCase):
     def test_bad_y(self):
         self.X, self.Y = get_dataset(return_X_y=True)
         Y = self.Y[:2]
-        print(self.X.shape, Y.shape)
         selector = GreedyTester(n_to_select=2)
         with self.assertRaises(ValueError):
             selector.fit(X=self.X, y=Y)

--- a/tests/test_kernel_normalizer.py
+++ b/tests/test_kernel_normalizer.py
@@ -41,12 +41,6 @@ class KernelTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             model.fit_transform(K, sample_weight=wts_dim)
 
-    def test_NoInputs(self):
-        """Checks that fit cannot be called with zero inputs."""
-        model = KernelNormalizer()
-        with self.assertRaises(ValueError):
-            model.fit()
-
     def test_ValueError(self):
         """Checks that a non-square matrix cannot be normalized."""
         K = self.random_state.uniform(0, 100, size=(3, 4))

--- a/tests/test_orthogonalizers.py
+++ b/tests/test_orthogonalizers.py
@@ -20,8 +20,8 @@ class TestXOrth(unittest.TestCase):
         self.random_state = np.random.RandomState(0)
 
     def setUp(self):
-        self.n_samples = 100
-        self.n_features = 100
+        self.n_samples = 2
+        self.n_features = 4
 
     def test_null_column(self):
         # checks that the column passed to the orthogonalizer
@@ -117,6 +117,7 @@ class TestXOrth(unittest.TestCase):
         X_correlated = X_orthogonalizer(
             X_correlated, x2=X_correlated[:, :n_uncorrelated]
         )
+        print(X_correlated)
 
         self.assertLessEqual(np.linalg.norm(X_correlated), EPSILON)
 
@@ -151,10 +152,12 @@ class TestXOrth(unittest.TestCase):
             -1, 1, size=(self.n_samples, self.n_features)
         )
 
+        print(X_random)
         idx = self.random_state.choice(X_random.shape[-1])
 
         new_X = X_orthogonalizer(X_random, idx, tol=EPSILON, copy=True)
         X_orthogonalizer(X_random, idx, tol=EPSILON, copy=False)
+        print(new_X, X_random)
         self.assertTrue(np.allclose(X_random, new_X))
 
 

--- a/tests/test_orthogonalizers.py
+++ b/tests/test_orthogonalizers.py
@@ -152,12 +152,10 @@ class TestXOrth(unittest.TestCase):
             -1, 1, size=(self.n_samples, self.n_features)
         )
 
-        print(X_random)
         idx = self.random_state.choice(X_random.shape[-1])
 
         new_X = X_orthogonalizer(X_random, idx, tol=EPSILON, copy=True)
         X_orthogonalizer(X_random, idx, tol=EPSILON, copy=False)
-        print(new_X, X_random)
         self.assertTrue(np.allclose(X_random, new_X))
 
 

--- a/tests/test_standard_flexible_scaler.py
+++ b/tests/test_standard_flexible_scaler.py
@@ -188,6 +188,14 @@ class ScalerTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             model.fit(X)
 
+    def test_not_w_mean(self):
+        """Checks that the matrix normalized `with_mean=False`
+        does not have a mean."""
+        X = np.array([2, 2, 3]).reshape(-1, 1)
+        model = StandardFlexibleScaler(with_mean=False)
+        model.fit(X)
+        self.assertTrue(np.allclose(model.mean_, 0))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
scikit-learn-contrib (our PR is https://github.com/scikit-learn-contrib/scikit-learn-contrib/issues/62) requires that all estimators pass a check_estimators test ala https://scikit-learn.org/stable/modules/generated/sklearn.utils.estimator_checks.parametrize_with_checks.html#sklearn.utils.estimator_checks.parametrize_with_checks, which ours were not currently doing. I've been going through everything that inherits from the BaseEstimator class (or should) and making the required changes. @agoscinski would appreciate your input on the `linear_models` section, as I'm not sure that OrthogonalRegression *can* pass the estimators, as to my knowledge the predicted values may have a different shape that the fitted y, no? Please correct me if I'm wrong.

<!-- readthedocs-preview scikit-matter start -->
----
:books: Documentation preview :books:: https://scikit-matter--196.org.readthedocs.build/en/196/

<!-- readthedocs-preview scikit-matter end -->